### PR TITLE
feat(conns): fix some hanging requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+tqdm
+requests


### PR DESCRIPTION
When using Burp Suite as a proxy, some requests that are large will fail. This is not a problem within this script but rather to do with Burp's own SSL stack and anti-bot behaviour from popular WAFs/CDNs such as Akamai and Cloudflare. None the less, we decided to ensure HTTP/1.1 where possible and added some additional headers to appease some WAFs.